### PR TITLE
member からの commit のテスト

### DIFF
--- a/1a52282f0b132347c2b1.md
+++ b/1a52282f0b132347c2b1.md
@@ -12,12 +12,11 @@ QiitaとQiitadonのユーザ間のコラボレーションを支援するため�
 
 - 簡潔・明瞭
 - 使って楽しい・作って楽しい
-- (未定)
+- コメント 10 回に 1 回はユーモアを
 - (未定)
 - (未定)
 
 追加予定です。max 5 件を目安とします。
-この流れだと、対の言葉をワンセットにしていくと美しそうです。
 
 ### Organization の運用ルールの参照先 ([items: issue #8](https://github.com/Qithub-BOT/items/issues/8))
 
@@ -25,24 +24,235 @@ QiitaとQiitadonのユーザ間のコラボレーションを支援するため�
 
 https://qiita.com/Qithub/private/1a52282f0b132347c2b1 
 
+### プロジェクト全体に関する相談窓口はどこ？ ([items: issue #1](https://github.com/Qithub-BOT/items/issues/1))
+
+- アイデア、気づいた点等、まずはProjectのノートから始める
+- ノートをissue化する際は、BOT関連以外はitemsリポジトリに置く
+
 ### issue をクローズしていい時の意思表示方法 ([items: issue #15](https://github.com/Qithub-BOT/items/issues/15))
 
-:thumbsup:(`:thumbsup:`)のみのコメントをした方は「意義なし！クローズしてよし！」と思っていることにします。
+1行目に:thumbsup:(`:thumbsup:`)のみをコメントをした方は「意義なし！クローズしてよし！」と思っていることにします。
+
+### ラベルを貼るルール ([items: issue #7](https://github.com/Qithub-BOT/items/issues/7))
+
+- issueは**ラベルなし**でスタートさせる
+- **ラベリング**は**ラベリング担当チーム**にまかせる
+- メンバーが増えたら Role を再考する(=担当者を増やす)
 
 ### 記事の更新をマージする条件 ([items: issue #13](https://github.com/Qithub-BOT/items/issues/13))
 
 - BOTのフォロワーと判断したら関係なく更新する
 - BOTのフォロワー以外からQiitaコラボ記事のリクエストが来た場合のみ、合議制（:thumbsup:(`:thumbsup:`)or:thumbsdown:(`:thumbsdown:`)を含む返信のカウント）が発動する
 
-### ラベルを貼るルール ([(items: issue #7)](https://github.com/Qithub-BOT/items/issues/7))
+### プロジェクトメンバーの勧誘基準 ([items: issue #12](https://github.com/Qithub-BOT/items/issues/12))
 
-- issueは**ラベルなし**でスタートさせる
-- **ラベリング**は**ラベリング担当チーム**にまかせる
-- メンバーが増えたら Role を再考する(=担当者を増やす)
+以下の条件を満たした人のうち、Organizationのメンバーから推薦を受けた人にお声がけする。
 
-### プロジェクト全体に関する相談窓口はどこ？ ([(items: issue #1)](https://github.com/Qithub-BOT/items/issues/1))
+- Qithub をフォローしている
+- 投票および改善要求を一回以上している
 
-- アイデア、気づいた点等、まずはProjectのノートから始める
-- ノートをissue化する際は、BOT関連以外はitemsリポジトリに置く
+なお、これは**こちらからアプローチする場合の基準**であり、自発的に参加希望がある場合は、これを拒まない。
+
+### 「Qithub」のロゴやキャラクター募集 ([items: issue #18](https://github.com/Qithub-BOT/items/issues/18))
+
+「擬人化したよ！」「キャラ作ったよ」など何かあれば、[items リポジトリの issue #18](https://github.com/Qithub-BOT/items/issues/18)にリクエストしてください。
+
+#### 案1 (current!)
+
+![Qithub icon](https://user-images.githubusercontent.com/11840938/30875728-61e0f35e-a32f-11e7-8079-907e3e248783.png)
+
+### BOT のコンセプト・目的 ([items: issue #4](https://github.com/Qithub-BOT/items/issues/4))
+
+#### Qithub 3 つの moe (注：more のもじり)
+
+- 共同執筆と互助
+- 帰属意識の向上
+- 楽しく環境改善
+
+### Toot の公開範囲の仕様 ([items: issue #11](https://github.com/Qithub-BOT/items/issues/11))
+
+#### トゥートの基本公開範囲
+
+- 基本は**非公開**とし、フォロワーのみが閲覧可能とする
+- フォロワーに関するものは**未収載**とし、フォロワー意外でも閲覧可能にする
+- フォロワーからの一定評価があった内容に関しては**公開**でトゥートする
+
+#### 新着Qiita記事の公開範囲
+
+- 定時（朝、昼、晩）トゥートは開始のアナウンスのみとし、**公開**でトゥート
+- cronによる定期チェックにより、新着Qiita記事のお知らせは定時トゥートに**非公開**で返信
+- 特例として、新着Qiita記事がフォロワーの記事の場合は**未収載**で返信
+- cronの定期チェックで「ブースト数」「お気に入り数」が一定数を超えたものは**公開**で別途トゥート
+
+※ 以下の機能に関しては、基本の実装が出来てからの拡張案件とし、別途 issue を立てることとします。
+
+>「フォロワーから個別にメンションされたタグを含む新着Qiita記事は、個別にフォロワーへダイレクト・トゥートする」機能
+
+### 記事原稿の保管パス ([items: issue #2](https://github.com/Qithub-BOT/items/issues/2))
+
+`items` リポジトリ直下にQiita記事と同じIDのファイル名で保存する。**ディレクトリの作成は禁止**
+
+- 理由：QiitaのURLが`items/<ドキュメントID>`となっているため
+
+```
+Qiita-BOTch (Organization)
+    ⊢ items (Repository)
+    ∣    ⊢ xxxxxxxxxx.md (Raw MD text of Qiita Doc ID xxxxxxxxxx )
+    ∣    ⊢ yyyyyyyyyyy.md (Raw MD text of Qiita Doc ID yyyyyyyyyyy )
+    ∣    ∟ zzzzzzzzzzz.md (Raw MD text of Qiita Doc ID zzzzzzzzzzz )
+    ∟scripts (Repository)
+         ∟ ??（未定）
+```
+
+### ラベル「緊急度：x」の指針 ([items: issue #6](https://github.com/Qithub-BOT/items/issues/6))
+
+[緊急度計算機](https://paiza.io/projects/yrd20tbK6h8qGdJnbit47A)（仮。paiza.IO にて）
+
+下図参照。
+
+![paiza.io: トリアージウィジェット prototype](https://user-images.githubusercontent.com/11840938/30850801-aae09c92-a2e1-11e7-8c88-cfa2c9831106.png)
+
+### カスタムラベルの名称と色 ([items: issue #5](https://github.com/Qithub-BOT/items/issues/5))
+
+リポジトリ`items`と`scripts`で共通です。
+
+|タグ名	|色コード	|
+|:--:|:---:|
+|不具合|	#ee0701|
+|保留|	#ffffff|
+|提案|	#fbca04|
+|無効|	#e6e6e6|
+|相談|	#33aa3f|
+|緊急度：中|	#ffff00|
+|緊急度：低|	#0e8a16|
+|緊急度：高|	#b60205|
+|質問|	#cc317c|
+|重複|	#cccccc|
+
+### BOTのネーミングとアカウント ([items: issue #9](https://github.com/Qithub-BOT/items/issues/9))
+
+- 表示名：Qithub(bot)
+- Qiitaアカウント名： qithub
+- Qiitadonアカウント名： qithub
+
+>Organization名を変更しましたが、「Qithub」が取られていた（アカウントはBANだった）ので「Qithub-BOT」で登録しました。
+
+#### Qiita のプロフィール情報
+
+|項目名|	設定値|
+|:--|:--|
+|名前：姓|	（空欄）|
+|名前：名|	Qithub(bot|)
+|公開メールアドレス|	非公開|
+|サイト/ブログ|	https://github.com/Qithub-BOT/
+|所属している組織・会社|	Qithub-BOT @ GitHub
+|居住地|	Japan|
+|自己紹介|	QiitaとQiitadonのユーザ間コラボレーションを支援するためのBOTをQiitaユーザーで作るためのGitHubのOrganization用アカウントです。|
+|Facebook ID|	（空欄）|
+|LinkedIn ID|	（空欄）|
+|Google+ ID|	（空欄）|
+
+#### Qiita のアカウント情報
+
+|項目名|	設定値|
+|:--|:--|
+|ユーザ名|	Qithub|
+|登録メールアドレス|	`qithub@keinos.com`|
+
+#### Qiita のユーザー画面
+
+https://qiita.com/qithub
+
+#### Qiitadonのアカウント情報
+
+https://qiitadon.com/@Qithub
+
+#### プロフィール情報
+
+|項目名|	設定内容|
+|:--|:--|
+|表示名|	Qithub(bot)|
+|プロフィール|	QiitaとQiitadonのユーザ間コラボレーションを支援するためのBOTです。このBOT自体もQiitaユーザのコラボによって作られています。[α版 2017/09/27 現在]|
+|Qiitaアカウント|	qithub|
+
+
+
+
+
+
+
+
+
+
+--------
 
 ## Qithub の仕様
+
+### BOT開発におけるマージの基準とデプロイ ([scripts: issue #5](https://github.com/Qithub-BOT/items/issues/5))
+
+#### 基本ルール
+
+##### BOT開発のマージは自動化しない
+
+- プルリクのマージは **issue に割り当てられた担当者**または**プログラミングチームのメンバー**が行う（割り当て方法は要検討）
+- コードレビューは基本的にしない。マージ後の不具合が多いようであれば別途検討する
+
+##### デプロイに関して
+
+- BOTの稼働先は当面 @KEINOS の個人サーバーで行う
+- マージされたものは自動的に上記サーバーに反映（デプロイ）されるようにする
+
+### BOTの実行間隔の仕様 ([scripts: issue #4](https://github.com/Qithub-BOT/items/issues/4))
+
+- cronによる5分間隔の起動（定例処理）
+- GitHubからのWebHookによる起動（随時処理）
+- URL直打ちによる起動（臨時処理）
+
+### BOT による新規Qiita記事の作成と同期の仕様 ([scripts: issue #3](https://github.com/Qithub-BOT/items/issues/3))
+
+#### Qiitaコラボ記事の新規作成
+
+- Qiita の Qithub アカウントで新規記事を作成、記事IDを取得する
+- 同記事IDで items リポジトリ（master）にテキストファイルを作成する
+- これらの動作はBOTが行うこととする（それまでは手動。2017/09/27 現在 @KEINOS が担当）
+
+#### items リポジトリの同期
+
+- items リポジトリにおけるファイル名は Qiita記事のIDと同じとする（README.mdのみ例外）
+- 拡張子は".md"とする（＜Qiita記事ID＞.md）
+- items リポジトリにはQiita側の Qithub のアカウントに存在しない記事は置いてはいけない（README.md 除く）
+
+#### BOTの動作
+
+1. ユーザA が Qiitadon から BOT にメンション・トゥート
+2. ユーザA の Qiita アカウントID を取得（＠ユーザA）
+3. トゥート内容に問題がなければ BOT が Qiita に限定公開で記事を新規作成
+4. Qiita記事IDを取得
+5. itemsリポジトリに同内容のMarkdownファイルを作成
+6. 記事を作成した旨を ユーザA のトゥートに返信
+7. ユーザA はitemsリポジトリをローカルにクローンし以降はGitの通常フロー
+
+### BOT の必須機能 ([scripts: issue #1](https://github.com/Qithub-BOT/items/issues/1))
+
+#### 対Qiitaの必須機能
+
+- Qiita記事の「作成とID取得」「更新」「削除」
+- 新着Qiita記事の取得
+
+#### 対GitHubの必須機能
+
+- GitHubからのWebHookによるトリガー起動
+- BOTからのマージの実行
+
+#### 対Qiitadonの必須機能
+
+- トゥートおよびトゥートIDの取得
+- トゥートIDに対する返信
+- 公開範囲を指定してトゥート or 返信
+- フォロワーの情報取得
+- フォロワーのQiitaでのユーザー名取得
+
+#### デプロイ先の必須機能
+
+- git cloneの実行によるアップデート（もしくはwgetなど）
+- cronによるWebHook実行（５分間隔）

--- a/1a52282f0b132347c2b1.md
+++ b/1a52282f0b132347c2b1.md
@@ -29,12 +29,12 @@ https://qiita.com/Qithub/private/1a52282f0b132347c2b1
 
 :thumbsup:(`:thumbsup:`)のみのコメントをした方は「意義なし！クローズしてよし！」と思っていることにします。
 
-### 「記事原稿第1版が完成している」かどうかを BOT から判断する方法 ([items: issue #13](https://github.com/Qithub-BOT/items/issues/13))
+### 記事の更新をマージする条件 ([items: issue #13](https://github.com/Qithub-BOT/items/issues/13))
 
 - BOTのフォロワーと判断したら関係なく更新する
 - BOTのフォロワー以外からQiitaコラボ記事のリクエストが来た場合のみ、合議制（:thumbsup:(`:thumbsup:`)or:thumbsdown:(`:thumbsdown:`)を含む返信のカウント）が発動する
 
-### ラベルを貼る時のタイミングのルール ([(items: issue #7)](https://github.com/Qithub-BOT/items/issues/7))
+### ラベルを貼るルール ([(items: issue #7)](https://github.com/Qithub-BOT/items/issues/7))
 
 - issueは**ラベルなし**でスタートさせる
 - **ラベリング**は**ラベリング担当チーム**にまかせる

--- a/1a52282f0b132347c2b1.md
+++ b/1a52282f0b132347c2b1.md
@@ -2,15 +2,47 @@
 
 タグ: 
 
+## Qithub とは
+
+QiitaとQiitadonのユーザ間のコラボレーションを支援するためのBOTを共同で作るためのOrganizationです。
+
 ## Organization の運営ルール
 
 ### 基本ルール（運営ポリシー）
-- 簡潔・明瞭
 
-### Organization の運用ルールの参照先
+- 簡潔・明瞭
+- 使って楽しい・作って楽しい
+- (未定)
+- (未定)
+- (未定)
+
+追加予定です。max 5 件を目安とします。
+この流れだと、対の言葉をワンセットにしていくと美しそうです。
+
+### Organization の運用ルールの参照先 ([items: issue #8](https://github.com/Qithub-BOT/items/issues/8))
 
 本記事です。
 
 https://qiita.com/Qithub/private/1a52282f0b132347c2b1 
+
+### issue をクローズしていい時の意思表示方法 ([items: issue #15](https://github.com/Qithub-BOT/items/issues/15))
+
+:thumbsup:(`:thumbsup:`)のみのコメントをした方は「意義なし！クローズしてよし！」と思っていることにします。
+
+### 「記事原稿第1版が完成している」かどうかを BOT から判断する方法 ([items: issue #13](https://github.com/Qithub-BOT/items/issues/13))
+
+- BOTのフォロワーと判断したら関係なく更新する
+- BOTのフォロワー以外からQiitaコラボ記事のリクエストが来た場合のみ、合議制（:thumbsup:(`:thumbsup:`)or:thumbsdown:(`:thumbsdown:`)を含む返信のカウント）が発動する
+
+### ラベルを貼る時のタイミングのルール ([(items: issue #7)](https://github.com/Qithub-BOT/items/issues/7))
+
+- issueは**ラベルなし**でスタートさせる
+- **ラベリング**は**ラベリング担当チーム**にまかせる
+- メンバーが増えたら Role を再考する(=担当者を増やす)
+
+### プロジェクト全体に関する相談窓口はどこ？ ([(items: issue #1)](https://github.com/Qithub-BOT/items/issues/1))
+
+- アイデア、気づいた点等、まずはProjectのノートから始める
+- ノートをissue化する際は、BOT関連以外はitemsリポジトリに置く
 
 ## Qithub の仕様

--- a/1a52282f0b132347c2b1.md
+++ b/1a52282f0b132347c2b1.md
@@ -1,3 +1,16 @@
-#タイトル
-#記事のハッシュタグ
-ここからが本文
+# Qihub 設定資料集
+
+タグ: 
+
+## Organization の運営ルール
+
+### 基本ルール（運営ポリシー）
+- 簡潔・明瞭
+
+### Organization の運用ルールの参照先
+
+本記事です。
+
+https://qiita.com/Qithub/private/1a52282f0b132347c2b1 
+
+## Qithub の仕様


### PR DESCRIPTION
Github 上から Qithub-BOT/items の記事へのコミット＆プルリクのテストをしています。

まずは大枠の

- Organization の運営ルール
- Qithub の仕様

という 2 部に分けました。今後は案件のタイトルに箇条書きを使わずヘッダを使い、Qitta の自動索引機能からたどれるようにしたいと考えています（本案件も合意があれば本記事に記載します）。

これができれば、git CLI が使えなくてもコラボレーションできますね♪