### PR TITLE
「Qiitaのプロフィール」内のテーブルと閉じかっこを修正

### DIFF
--- a/1a52282f0b132347c2b1.md
+++ b/1a52282f0b132347c2b1.md
@@ -142,10 +142,10 @@ Qiita-BOTch (Organization)
 |項目名|	設定値|
 |:--|:--|
 |名前：姓|	（空欄）|
-|名前：名|	Qithub(bot|)
+|名前：名|	Qithub(bot)|
 |公開メールアドレス|	非公開|
-|サイト/ブログ|	https://github.com/Qithub-BOT/
-|所属している組織・会社|	Qithub-BOT @ GitHub
+|サイト/ブログ| https://github.com/Qithub-BOT/ |
+|所属している組織・会社|	Qithub-BOT @ GitHub |
 |居住地|	Japan|
 |自己紹介|	QiitaとQiitadonのユーザ間コラボレーションを支援するためのBOTをQiitaユーザーで作るためのGitHubのOrganization用アカウントです。|
 |Facebook ID|	（空欄）|


### PR DESCRIPTION
## 編集内容

- `Qithub(bot|)`→`Qithub(bot)|`
- テーブルMarkdownの`|`の抜けを修正

## 対象チケット番号

なし

## 補足

なし