### PR TITLE
CODE_OF_CONDUCT.md の追加

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,17 @@
+# 行動規範
+
+## 基本ルール（運営ポリシー）
+
+- KISS: 簡潔
+- CLEAR: 明瞭
+- HAPPY: 楽しく作って、楽しく使える
+- FUNNY: いつもどこかにユーモアを
+- 👍 😄 🤔 : emoji でシンプルに気持ちを伝えよう
+
+## コンセプト・目的 ([items #4](https://github.com/Qithub-BOT/items/issues/4))
+
+### Qithub 3 つの moe (注：more のもじり)
+
+- 共同執筆と互助
+- 帰属意識の向上
+- 楽しく環境改善


### PR DESCRIPTION
Github の <https://github.com/Qithub-BOT/items/community> 的には、トップまたは
.github/ 内に CODE_OF_CONDUCT.md として行動規範を示すことを推奨しています。

さっそくつくってみました。

## 対象トピック番号

なし

## 補足

## TL;DR（進捗・結論 2017/11/03 現在）

- 審議中 ( ´・ω) (´・ω・) (・ω・｀) (ω・｀ )