### PR TITLE
fix: #145 スチャマーの Typo を修正（"schama" -> "schema"）

### DIFF
--- a/api/v1/.lib/php/tootlib.php.inc
+++ b/api/v1/.lib/php/tootlib.php.inc
@@ -69,7 +69,6 @@ namespace { // 汎用のため明示的にグローバル名前空間に設置
 
 /* ---------------------------------------------------------------------- [D] */
 
-    /** * @SuppressWarnings(PHPMD.ExitExpression) */
     function dieMsg($msg, $status = STATUS_OK)
     {
         if (! is_string($msg)) {
@@ -332,7 +331,7 @@ namespace { // 汎用のため明示的にグローバル名前空間に設置
      */
     function toot(array $settings)
     {
-        $settings['schama']   = 'https';
+        $settings['schema']   = 'https';
         $settings['endpoint'] = '/api/v1/statuses';
         $settings['method']   = 'POST';
 


### PR DESCRIPTION
## 対象トピック番号

#145

## TL;DR（結論 2018/09/19 現在）

- 卍済み
