### PR TITLE
fix: #143 アクセストークンのリクエストキー修正 "qithub" -> "qiitime"

### DIFF
--- a/api/v1/qiitime/index.php
+++ b/api/v1/qiitime/index.php
@@ -82,7 +82,7 @@ $settings['result'] = toot([
     'host'         => 'qiitadon.com',
     'visibility'   => 'unlisted',           // タイプ: public, unlisted, private
     'name_service' => 'qiitadon',           // `gettoken` 第１引数
-    'name_token'   => 'qithub',             // `gettoken` 第２引数
+    'name_token'   => 'qiitime',            // `gettoken` 第２引数
     'spoiler_text' => $msg['spoiler_text'], // CW 警告文
     'status'       => $msg['status'],       // トゥート本体
 ]);


### PR DESCRIPTION
## 対象トピック番号

#143 

## TL;DR（結論 2018/09/19 現在）

すでに数回別アカウントでトゥートしているため、CI チェックが通ったら 😎 で 卍 します。

- 卍済み
