### PR TITLE
fix: #159 コンマ付きタグのエスケープ

### DIFF
--- a/api/v1/qiita-items/functions.php.inc
+++ b/api/v1/qiita-items/functions.php.inc
@@ -90,7 +90,7 @@ function escapeTagForMastodon($string)
     $string = str_replace('c#', 'CSharp', $string_lower);
 
     $string = str_replace(
-        ['.', '-', ' ', '/'],
+        ['.', '-', ' ', '/', ','],
         '_',
         $string
     );


### PR DESCRIPTION
## 対象トピック番号

#159 関連
https://qiitadon.com/@qithub/100882058157262215 の FIX

