### PR TITLE
Qiita-Cache（魚拓）API の生 JSON 取得時にアクセストークン利用を実装

### DIFF
--- a/api/v1/.lib/php/function_Common.php.inc
+++ b/api/v1/.lib/php/function_Common.php.inc
@@ -108,7 +108,7 @@ namespace { // 汎用のため明示的にグローバル名前空間に設置
         //アクセス過多による BAN 防止
         //   Qiita は制限が厳しいので注意
         //     未認証    1 request / min
-        //     認証済み 16 request / min (3/sec)
+        //     認証済み 16 request / min (1req/3sec)
         sleep(REQUEST_LIMIT_PER_SEC);
 
         if (! empty($access_token)) {

--- a/api/v1/.lib/php/function_Common.php.inc
+++ b/api/v1/.lib/php/function_Common.php.inc
@@ -86,7 +86,7 @@ namespace { // 汎用のため明示的にグローバル名前空間に設置
         return file_get_contents($path_file);
     }
 
-    function getContentsFromUrl($url)
+    function getContentsFromUrl($url, $access_token = '')
     {
         static $results;
 
@@ -96,11 +96,27 @@ namespace { // 汎用のため明示的にグローバル名前空間に設置
             return $results[$crc];
         }
 
-        sleep(REQUEST_LIMIT_PER_SEC); //アクセス過多による BAN 防止
-
         // コンテンツの取得
         $http_response_header = null;
-        $result = @file_get_contents($url);
+        $context = [
+            'http' => [
+                'method' => 'GET',
+                'ignore_errors' => true,
+            ],
+        ];
+
+        //アクセス過多による BAN 防止
+        //   Qiita は制限が厳しいので注意
+        //     未認証    1 request / min
+        //     認証済み 16 request / min (3/sec)
+        sleep(REQUEST_LIMIT_PER_SEC);
+
+        if (! empty($access_token)) {
+            $header = "Authorization: Bearer ${access_token}\r\n";
+            $context['http']['header'] = $header;
+        }
+
+        $result = @file_get_contents($url, false, stream_context_create($context));
 
         if (false === $result) {
             $error  = "Error occurred while fetching url: {$url}" . PHP_EOL;

--- a/api/v1/qiita-cache/functions.php.inc
+++ b/api/v1/qiita-cache/functions.php.inc
@@ -11,16 +11,18 @@ function copyCacheToSpams($json)
         return false;
     }
 
-    $id_item        = getItemIdGiven();
+    $id_item        = getItemIdGiven(); // リクエスト記事ID
     $path_file_spam = getPathFileSpam($id_item);
 
     if (file_exists($path_file_spam)) {
-        return true;
+        return true; // すでに墓場行きなら処理済み
     }
 
     $array = json_decode($json, JSON_OBJECT_AS_ARRAY);
     $user  = \getValue('user', $array, []);
 
+    // 下記 JSON に含めるスパム info のコンテンツ仕様は Issue #152 より
+    // https://github.com/Qithub-BOT/Qithub-ORG/issues/152
     $result['id_item']   = \getValue('id', $array);
     $result['id_user']   = \getValue('id', $user);
     $result['url_cache'] = URL_ENDPOINT_BASE  . '?id=' . $id_item;
@@ -81,6 +83,34 @@ function echoTagsAsCommonFormat($tags_search, $return = RETURN_AS_ARRAY)
 
 /* ---------------------------------------------------------------------- [G] */
 
+function getAccessToken($name_service, $name_token)
+{
+    // 2018/11/08 現在の取得可能なアクセストークン一覧
+    // name_service = [qiitadon, qiita]
+    // name_token = [qithub, qithub-dev, qiitime, test] （サービスのアカウント）
+    // 
+    // ※ サーバーの gettoken コマンドを利用するには事前に申請許可と、リクエスト
+    //    元のディレクトリをアクセス・リストに追加してもらう必要があります。
+    //    詳しくは Qithub-ORG リポジトリ Wiki の「アクセストークンについて」参照
+
+    $command    = "gettoken ${name_service} ${name_token}";
+    $output     = [];
+    $return_var = 1;
+    $lastline   = exec($command, $output, $return_var);
+
+    return (0 === $return_var) ? $lastline : false;
+}
+
+function getAccessTokenQiita()
+{
+    // アクセストークンの取得許可済み
+    // https://github.com/Qithub-BOT/Qithub-ORG/issues/168
+    $name_service = 'qiita';
+    $name_token   = 'qithub';
+
+    return getAccessToken($name_service, $name_token);
+}
+
 function getItemIdGiven()
 {
     static $result;
@@ -109,13 +139,17 @@ function getJsonItemFromApi($id_item)
     if (empty($id_item)) {
         return false;
     }
+    
+    $access_token_qiita = getAccessTokenQiita();
 
     $url  = URL_ENDPOINT_QIITA . $id_item;
-    $json = \getContentsFromUrl($url);
+    $json = \getContentsFromUrl($url, $access_token_qiita);
 
     if (null === json_decode($json)) {
         return false;
     }
+    
+    sleep(3); // Qiita API のアクセス制限が 16 request/min
 
     return $json;
 }

--- a/api/v1/qiita-cache/functions.php.inc
+++ b/api/v1/qiita-cache/functions.php.inc
@@ -88,12 +88,12 @@ function getAccessToken($name_service, $name_token)
     // 2018/11/08 現在の取得可能なアクセストークン一覧
     // name_service = [qiitadon, qiita]
     // name_token = [qithub, qithub-dev, qiitime, test] （サービスのアカウント）
-    // 
+    //
     // ※ サーバーの gettoken コマンドを利用するには事前に申請許可と、リクエスト
     //    元のディレクトリをアクセス・リストに追加してもらう必要があります。
     //    詳しくは Qithub-ORG リポジトリ Wiki の「アクセストークンについて」参照
 
-    $command    = "gettoken ${name_service} ${name_token}";
+    $command    = "gettoken {$name_service} {$name_token}";
     $output     = [];
     $return_var = 1;
     $lastline   = exec($command, $output, $return_var);
@@ -139,7 +139,7 @@ function getJsonItemFromApi($id_item)
     if (empty($id_item)) {
         return false;
     }
-    
+
     $access_token_qiita = getAccessTokenQiita();
 
     $url  = URL_ENDPOINT_QIITA . $id_item;
@@ -148,7 +148,7 @@ function getJsonItemFromApi($id_item)
     if (null === json_decode($json)) {
         return false;
     }
-    
+
     sleep(3); // Qiita API のアクセス制限が 16 request/min
 
     return $json;


### PR DESCRIPTION
Qiita API から記事の JSON 取得が、1 リクエスト／分 であるため、アクセストークンを利用して 1 リクエスト／ 3秒 （1,000 request/時）まで高めました。

## 対象トピック番号
https://github.com/Qithub-BOT/Qithub-ORG/issues/168

