### PR TITLE
fix: 溜まり場の招待リンクが期限切れになっていたので張り替え

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Qithub サークルでは GitHub の Organization メンバーをメンテナと
 
 ### 溜まり場
 
-<img src="https://raw.githubusercontent.com/Qithub-BOT/Qithub-ORG/master/images/Icon_QiitadonBar/QiitadonBar-v2_512x512.png" width=80 align=left> [溜まり場 @ Qiitadon酒場hidao店](https://discord.gg/JevmsM7) @ Discord ※
+<img src="https://raw.githubusercontent.com/Qithub-BOT/Qithub-ORG/master/images/Icon_QiitadonBar/QiitadonBar-v2_512x512.png" width=80 align=left> [溜まり場 @ Qiitadon酒場hidao店](https://discord.gg/D9bkXYz) @ Discord ※
 
 Qiitadon酒場は 24h/7d オープンのオンライン酒場です。Qiitadon とは違った雰囲気でドリンク・食べ物持参で、まったりとチャットしています。たまにライブ配信もしています。
 


### PR DESCRIPTION
すみません、チャットサーバ運用がでたらめのため、こちらにも影響が出てしまっています…

## 対象トピック番号

なし

## TL;DR（結論 2018/11/18 現在）

- 卍済み