### PR TITLE
Issue #173 タグ名検索の表示結果精度

### DIFF
--- a/api/v1/qiita-cache/README.md
+++ b/api/v1/qiita-cache/README.md
@@ -22,7 +22,7 @@ Qiita のスパム記事のスパム検知エンジン開発などにご利用�
 
 キャッシュされた Qiita 記事の情報が取得できます。
 
-- クエリ引数：`id`
+- クエリ引数： `id` （必須）
     - 取得したい Qiita 記事の ID を指定します。20 桁の16 進数で表現されています。
         ```
         https://qithub.tk/api/v1/qiita-cache/?id=<Qiita記事ID>
@@ -32,7 +32,7 @@ Qiita のスパム記事のスパム検知エンジン開発などにご利用�
         ```
         https://qithub.tk/api/v1/qiita-cache/?id=599c4f3b5a25370f8505
         ```
- - クエリ引数： `update`（オプション）
+ - クエリ引数： `update` （オプション）
     - 値が指定されていると最新の記事情報が取得できます。（キャッシュの内容も更新されます）
     - 値が空白、もしくは記事がすでに削除されている場合は更新しません。
 
@@ -54,15 +54,20 @@ Qiita のスパム記事のスパム検知エンジン開発などにご利用�
 
 #### GET `/api/v1/qiita-cache/?tag=`
 
-キャッシュされた Qiita 記事で最も使われているタグの表記方法を取得できます。タグが存在しない（使われたことがない）場合は、デフォルトで同じタグが返されます。
+キャッシュされた Qiita 記事で**最も使われているタグの表記方法を取得**できます。
 
-- クエリ引数：`tag`
-    - URL エンコードされたタグ名です。スペース（`%20`）区切りで複数タグも指定できます。
+キャッシュ記事や Qiita API にも検索タグが存在しない／使われたことがない場合は、デフォルトで検索タグが返されます。
+
+- クエリ引数： `tag` （必須）
+    - 値
+        - URL エンコードされたタグ名です。スペース（`%20`）区切りで複数タグも指定できます。
+
         ```
         https://qithub.tk/api/v1/qiita-cache/?tag=<URLエンコードのタグ>
         ```
 
     - Example: `"javascript%20TomCAT"`
+
         ```
         https://qithub.tk/api/v1/qiita-cache/?tag=javascript%20TomCAT%20JerryMOUSE
         ```
@@ -74,13 +79,16 @@ Qiita のスパム記事のスパム検知エンジン開発などにご利用�
         ]
         ```
 
-- クエリ引数：`only_used`（オプション）
-    - 値が指定されていると、タグがキャッシュや本家の API にも存在しない場合は空白を返します。
-    - 値が空白、もしくはクエリの指定がない場合は、検索タグを返します。
-
+- クエリ引数： `return_value` （オプション）
+    - 値
+        - `self_if_not_used` （デフォルト）
+            - タグが存在しない場合、検索タグ自身を返します。
+        - `only_used`
+            - タグが存在しない場合、空の値を返します。
+        - 値が指定されていない場合は、デフォルト値が使われます。
     - Example:
         ```
-        https://qithub.tk/api/v1/qiita-cache/?tag=javascript%20TomCAT%20JerryMOUSE&only_used=bar
+        https://qithub.tk/api/v1/qiita-cache/?tag=javascript%20TomCAT%20JerryMOUSE&return_value=only_used
         ```
         ```json
         [

--- a/api/v1/qiita-cache/README.md
+++ b/api/v1/qiita-cache/README.md
@@ -6,7 +6,7 @@
 https://qithub.tk/api/v1/qiita-cache/
 ```
 
-この API にリクエストがあると、指定された Qiita 記事 ID のキャッシュが JSON 形式で取得できます。
+この API にリクエストがあると、指定された Qiita 記事 ID のキャッシュ情報が JSON 形式で取得できます。
 
 ## 用途＆利用対象者
 
@@ -14,20 +14,16 @@ Qiita のスパム記事のスパム検知エンジン開発などにご利用�
 
 この API は Qiita をより良くしたいユーザーのためのサービスです。心無い利用が多いと判断した場合は、Qiita の OAuth を必須とするなど検討いたします。
 
-## スパム・フラグ
-
-出力される JSON データの "is_spam" 要素（値：true/false）はキャッシュ・サーバーが付加したものです。
-
-**これは簡易的なスパム検知**で、キャッシュ時に、ユーザーおよび該当記事が削除されていた場合、スパム記事と見なされフラグが立てられます。
-
-そのため、ユーザー本人が退会および記事の削除を行った可能性もあるためスパムでない可能性もあります。
-
 ## エンドポイントとメソッド
 
-### GET `/api/v1/qiita-cache/?id=`
+### 記事取得
 
-- id
-    - 取得したい Qiita 記事の ID です。20 桁の16 進数で表現されています。
+#### GET `/api/v1/qiita-cache/?id=`
+
+キャッシュされた Qiita 記事の情報が取得できます。
+
+- クエリ引数：`id`
+    - 取得したい Qiita 記事の ID を指定します。20 桁の16 進数で表現されています。
         ```
         https://qithub.tk/api/v1/qiita-cache/?id=<Qiita記事ID>
         ```
@@ -36,20 +32,62 @@ Qiita のスパム記事のスパム検知エンジン開発などにご利用�
         ```
         https://qithub.tk/api/v1/qiita-cache/?id=599c4f3b5a25370f8505
         ```
+ - クエリ引数： `update`（オプション）
+    - 値が指定されていると最新の記事情報が取得できます。（キャッシュの内容も更新されます）
+    - 値が空白、もしくは記事がすでに削除されている場合は更新しません。
 
-オプションで `&update=true` をリクエスト・クエリに加えるとキャッシュの内容を更新します。（削除済みを除く）
+    - Example:
+        ```
+        https://qithub.tk/api/v1/qiita-cache/?id=599c4f3b5a25370f8505&update=hoge
+        ```
 
-### GET `/api/v1/qiita-cache/?tag=`
+#### JSON のフォーマット
 
-- tag
-    - URL エンコードされたタグ名です。キャッシュされた情報から最も出現率の多いタグの表記で返されます。スペース（`%20`）区切りで複数タグも指定できます。
+返される JSON は、本家 Qiita の API の JSON 仕様に、スパム・フラグの要素を加えたものです。
+
+- [Qiita API v2 投稿](https://qiita.com/api/v2/docs#%E6%8A%95%E7%A8%BF) @ Qiita
+- スパム・フラグ
+    - 要素名："`is_spam`"、型：`string`、値：`true`/`false`
+    - **これは簡易的なスパム検知**です。キャッシュ時に、ユーザーおよび該当記事が削除されていた場合、スパム記事と見なされフラグが立てられます。そのため、ユーザー本人が退会および記事の削除を行った可能性もあるためスパムでない可能性もあります。
+
+### タグ取得
+
+#### GET `/api/v1/qiita-cache/?tag=`
+
+キャッシュされた Qiita 記事で最も使われているタグの表記方法を取得できます。タグが存在しない（使われたことがない）場合は、デフォルトで同じタグが返されます。
+
+- クエリ引数：`tag`
+    - URL エンコードされたタグ名です。スペース（`%20`）区切りで複数タグも指定できます。
         ```
         https://qithub.tk/api/v1/qiita-cache/?tag=<URLエンコードのタグ>
         ```
 
     - Example: `"javascript%20TomCAT"`
         ```
-        https://qithub.tk/api/v1/qiita-cache/?tag=javascript%20TomCAT
+        https://qithub.tk/api/v1/qiita-cache/?tag=javascript%20TomCAT%20JerryMOUSE
+        ```
+        ```json
+        [
+            "JavaScript",
+            "Tomcat",
+            "JerryMOUSE"
+        ]
+        ```
+
+- クエリ引数：`only_used`（オプション）
+    - 値が指定されていると、タグがキャッシュや本家の API にも存在しない場合は空白を返します。
+    - 値が空白、もしくはクエリの指定がない場合は、検索タグを返します。
+
+    - Example:
+        ```
+        https://qithub.tk/api/v1/qiita-cache/?tag=javascript%20TomCAT%20JerryMOUSE&only_used=fuga
+        ```
+        ```json
+        [
+            "JavaScript",
+            "Tomcat",
+            ""
+        ]
         ```
 
 

--- a/api/v1/qiita-cache/README.md
+++ b/api/v1/qiita-cache/README.md
@@ -38,7 +38,7 @@ Qiita のスパム記事のスパム検知エンジン開発などにご利用�
 
     - Example:
         ```
-        https://qithub.tk/api/v1/qiita-cache/?id=599c4f3b5a25370f8505&update=hoge
+        https://qithub.tk/api/v1/qiita-cache/?id=599c4f3b5a25370f8505&update=foo
         ```
 
 #### JSON のフォーマット
@@ -68,9 +68,9 @@ Qiita のスパム記事のスパム検知エンジン開発などにご利用�
         ```
         ```json
         [
-            "JavaScript",
-            "Tomcat",
-            "JerryMOUSE"
+            "javascript": "JavaScript",
+            "TomCAT": "Tomcat",
+            "JerryMOUSE": "JerryMOUSE"
         ]
         ```
 
@@ -80,13 +80,13 @@ Qiita のスパム記事のスパム検知エンジン開発などにご利用�
 
     - Example:
         ```
-        https://qithub.tk/api/v1/qiita-cache/?tag=javascript%20TomCAT%20JerryMOUSE&only_used=fuga
+        https://qithub.tk/api/v1/qiita-cache/?tag=javascript%20TomCAT%20JerryMOUSE&only_used=bar
         ```
         ```json
         [
-            "JavaScript",
-            "Tomcat",
-            ""
+            "javascript": "JavaScript",
+            "TomCAT": "",
+            "JerryMOUSE": ""
         ]
         ```
 

--- a/api/v1/qiita-cache/constants.php.inc
+++ b/api/v1/qiita-cache/constants.php.inc
@@ -14,6 +14,9 @@ const EXT_FILE_CACHE          = '.json'; // キャッシュファイルの拡張
 const URL_ENDPOINT_BASE       = 'https://qithub.tk/api/v1/qiita-cache/';
 const URL_ENDPOINT_QIITA_ITEM = 'https://qiita.com/api/v2/items/';
 const URL_ENDPOINT_QIITA_TAG  = 'https://qiita.com/api/v2/tags/';
+const QUERY_KEY_ONLY_USED     = 'return_value';
+const RETURN_SELF             = 'self_if_not_used';
+const RETURN_EMPTY            = 'only_used';
 
 define('TIME_NOW', time());
 define('PATH_DIR_CURR', dirname(__FILE__));

--- a/api/v1/qiita-cache/constants.php.inc
+++ b/api/v1/qiita-cache/constants.php.inc
@@ -4,15 +4,16 @@ namespace Qithub\QiitaCache;
 /* [Constants] ============================================================== */
 
 // 内部環境定数
-const FORMAT_THRESHOLD_FETCH = 'YmdHi'; // 201808302059 フォーマット
-const FOTMAT_THRESHOLD_HOUR  = 'YmdH';  //
-const REQUEST_LIMIT_PER_SEC  = 1;       // QiitaAPI は 1リクエスト/sec (60/hour)
-const NUM_PAGES_TO_FETCH     = 2;       // 1リクエストで取得する記事数
-const IS_SPAM                = true;
-const NOT_SPAM               = false;
-const EXT_FILE_CACHE         = '.json'; // キャッシュファイルの拡張子
-const URL_ENDPOINT_BASE      = 'https://qithub.tk/api/v1/qiita-cache/';
-const URL_ENDPOINT_QIITA     = 'https://qiita.com/api/v2/items/';
+const FORMAT_THRESHOLD_FETCH  = 'YmdHi'; // 201808302059 フォーマット
+const FOTMAT_THRESHOLD_HOUR   = 'YmdH';  //
+const REQUEST_LIMIT_PER_SEC   = 1;       // QiitaAPI は 1リクエスト/sec (60/hour)
+const NUM_PAGES_TO_FETCH      = 2;       // 1リクエストで取得する記事数
+const IS_SPAM                 = true;
+const NOT_SPAM                = false;
+const EXT_FILE_CACHE          = '.json'; // キャッシュファイルの拡張子
+const URL_ENDPOINT_BASE       = 'https://qithub.tk/api/v1/qiita-cache/';
+const URL_ENDPOINT_QIITA_ITEM = 'https://qiita.com/api/v2/items/';
+const URL_ENDPOINT_QIITA_TAG  = 'https://qiita.com/api/v2/tags/';
 
 define('TIME_NOW', time());
 define('PATH_DIR_CURR', dirname(__FILE__));

--- a/api/v1/qiita-cache/functions.php.inc
+++ b/api/v1/qiita-cache/functions.php.inc
@@ -63,7 +63,11 @@ function echoJson($json_string, $is_spam = null, $options = \JSON_COMMON_OPTION)
 
 function echoTagsAsCommonFormat($tags_search, $return = RETURN_AS_ARRAY)
 {
-    global $tag_only_used;
+    global $_GET;
+
+    // 未使用タグの場合の戻り値を空にするフラグを取得
+    $tag_only_used   = \getValue(QUERY_KEY_ONLY_USED, $_GET, RETURN_SELF);
+    $return_as_empty = (RETURN_EMPTY === strtolower($tag_only_used));
 
     $result = [];
 
@@ -80,7 +84,7 @@ function echoTagsAsCommonFormat($tags_search, $return = RETURN_AS_ARRAY)
             $result[$tag_search_raw] = $tag_search;
             continue;
         }
-        
+
         // Qiita API に存在する場合
         $tag_search = getJsonTagFromApi($tag_search_raw);
 
@@ -90,8 +94,8 @@ function echoTagsAsCommonFormat($tags_search, $return = RETURN_AS_ARRAY)
         }
 
         // タグが存在しない場合
-        // $tag_only_used != true 同じタグ名を返す(仕様 Issue173）
-        $result[$tag_search_raw] = ($tag_only_used) ? '' : $tag_search_raw;
+        // $return_as_empty != true 同じタグ名を返す(仕様 Issue173）
+        $result[$tag_search_raw] = ($return_as_empty) ? '' : $tag_search_raw;
     }
 
     if (RETURN_AS_JSON === $return) {
@@ -184,7 +188,7 @@ function getJsonTagFromApi($tag_search)
 
     $url  = URL_ENDPOINT_QIITA_TAG . urldecode($tag_search);
 
-    if(\isUrl404($url)){
+    if (\isUrl404($url)) {
         return '';
     }
 

--- a/api/v1/qiita-cache/functions.php.inc
+++ b/api/v1/qiita-cache/functions.php.inc
@@ -26,7 +26,7 @@ function copyCacheToSpams($json)
     $result['id_item']   = \getValue('id', $array);
     $result['id_user']   = \getValue('id', $user);
     $result['url_cache'] = URL_ENDPOINT_BASE  . '?id=' . $id_item;
-    $result['url_raw']   = URL_ENDPOINT_QIITA . $id_item;
+    $result['url_raw']   = URL_ENDPOINT_QIITA_ITEM . $id_item;
     $result['date_post'] = \getValue('created_at', $array);
 
     $json = json_encode($result, \JSON_COMMON_OPTION);
@@ -42,38 +42,56 @@ function echoJson($json_string, $is_spam = null, $options = \JSON_COMMON_OPTION)
         \dieMsg('Invalid JSON given.(JSON empty)', __LINE__);
     }
 
+    // is_spam 要素の追加
     $array = json_decode($json_string, JSON_OBJECT_AS_ARRAY);
-    
-    if(null !== $is_spam){
-        $array['is_spam'] = (IS_SPAM === $is_spam);    
+    if (null !== $is_spam) {
+        $array['is_spam'] = (IS_SPAM === $is_spam);
     }
 
+    // JSON ヘッダの出力
     $json_string = json_encode($array, $options);
     $etag        = hash('md5', $json_string);
-
     if (! \isCli() && ! headers_sent()) {
         header('Content-type: application/json; charset=utf-8');
         header('Content-Length: '.strlen($json_string));
         header('Etag: ' . $etag);
     }
 
+    // JSON の出力
     echo $json_string;
 }
 
 function echoTagsAsCommonFormat($tags_search, $return = RETURN_AS_ARRAY)
 {
+    global $tag_only_used;
+
     $result = [];
 
     if (is_string($tags_search)) {
         $tags_search[] = $tags_search;
     }
 
-    foreach ($tags_search as $tag_search) {
-        $tag_search = stripTagAsKey($tag_search);
+    foreach ($tags_search as $tag_search_raw) {
+        $tag_search = stripTagAsKey($tag_search_raw);
         $tag_search = getTagAsCommonFormat($tag_search);
+
+        // キャッシュに存在する場合
         if (! empty($tag_search)) {
-            $result[] = $tag_search;
+            $result[$tag_search_raw] = $tag_search;
+            continue;
         }
+        
+        // Qiita API に存在する場合
+        $tag_search = getJsonTagFromApi($tag_search_raw);
+
+        if (! empty($tag_search)) {
+            $result[$tag_search_raw] = $tag_search;
+            continue;
+        }
+
+        // タグが存在しない場合
+        // $tag_only_used != true 同じタグ名を返す(仕様 Issue173）
+        $result[$tag_search_raw] = ($tag_only_used) ? '' : $tag_search_raw;
     }
 
     if (RETURN_AS_JSON === $return) {
@@ -145,7 +163,7 @@ function getJsonItemFromApi($id_item)
 
     $access_token_qiita = getAccessTokenQiita();
 
-    $url  = URL_ENDPOINT_QIITA . $id_item;
+    $url  = URL_ENDPOINT_QIITA_ITEM . $id_item;
     $json = \getContentsFromUrl($url, $access_token_qiita);
 
     if (null === json_decode($json)) {
@@ -156,6 +174,28 @@ function getJsonItemFromApi($id_item)
     sleep(3); // Qiita API のアクセス制限が 16 request/min
 
     return $json;
+}
+
+function getJsonTagFromApi($tag_search)
+{
+    if (empty($tag_search)) {
+        return '';
+    }
+
+    $url  = URL_ENDPOINT_QIITA_TAG . urldecode($tag_search);
+
+    if(\isUrl404($url)){
+        return '';
+    }
+
+    $access_token_qiita = getAccessTokenQiita();
+    $json  = \getContentsFromUrl($url, $access_token_qiita);
+    $array = json_decode($json, JSON_OBJECT_AS_ARRAY);
+    if (null === $array) {
+        return '';
+    }
+
+    return \getValue('id', $array, '');
 }
 
 function getNameTagGiven($return = RETURN_AS_ARRAY)
@@ -259,14 +299,13 @@ function getTagAsCommonFormat($name_tag)
     if (! isset($list_tags)) {
         // 出現タグ一覧の再利用に static 変数に代入
         $list_tags = getTagsFromFileAsArray(getPathFileTags());
-        //$list_tags = getContentsFromFile(getPathFileTags());
     }
 
     $key = stripTagAsKey($name_tag);
 
-    // 初出現の場合は同じタグを返す
+    // キャッシュにタグがない場合
     if (! isset($list_tags[$key])) {
-        return $name_tag;
+        return '';
     }
 
     // 該当タグの出現リストから最大出現数のタグを返す
@@ -488,7 +527,9 @@ function putTagsToFile($path_file_tags, $json)
     foreach ($tags as $tag) {
         $name_tag = $tag['name'];
         $key      = stripTagAsKey($name_tag);
-        $name_tag = getTagAsCommonFormat($name_tag);
+        $name_tag = getTagAsCommonFormat($name_tag) ?: $name_tag;
+
+        // タグの出現回数カウントアップ
         $count    = 1;
         if (isset($result[$key][$name_tag])) {
             $count = ++$result[$key][$name_tag];

--- a/api/v1/qiita-cache/index.php
+++ b/api/v1/qiita-cache/index.php
@@ -39,10 +39,6 @@ $name_tags = getNameTagGiven(\RETURN_AS_ARRAY);
 
 // 指定されたタグの最も使われている表記方法（キャッシュ内に限る）を返して終了
 if (! empty($name_tags)) {
-
-    // 未使用タグの場合の戻り値を空にするフラグを取得
-    $tag_only_used = \getValue('only_used', $_GET) ? true : false;
-
     echoTagsAsCommonFormat($name_tags, \RETURN_AS_JSON);
     exit(\STATUS_OK);
 }

--- a/api/v1/qiita-cache/index.php
+++ b/api/v1/qiita-cache/index.php
@@ -39,6 +39,10 @@ $name_tags = getNameTagGiven(\RETURN_AS_ARRAY);
 
 // 指定されたタグの最も使われている表記方法（キャッシュ内に限る）を返して終了
 if (! empty($name_tags)) {
+
+    // 未使用タグの場合の戻り値を空にするフラグを取得
+    $tag_only_used = \getValue('only_used', $_GET) ? true : false;
+
     echoTagsAsCommonFormat($name_tags, \RETURN_AS_JSON);
     exit(\STATUS_OK);
 }


### PR DESCRIPTION
## 対象トピック番号

#174 「【報告】Qiita-cache API で存在しないタグについて検索した場合」を対応しました。

### FEAT
1. キャッシュにタグがない場合、Qiita API も確認するようにした
2. タグが存在しない場合、戻り値を「検索タグ自身」と「空」の２択をできるようにした
3. レスポンスで返す JSON 配列のキーの添字に検索タグを使うようにした
