### PR TITLE
Delete -ssl option from openssl rsautl command

### DIFF
--- a/tools/crypt/enc
+++ b/tools/crypt/enc
@@ -101,7 +101,7 @@ echo "OK"
 #       4096 =  502
 #       8192 = 1018
 echo -n "公開鍵でファイルを暗号化中 ... "
-openssl rsautl -encrypt -pubin -inkey $PATHPUBKEY.pkcs8 -ssl -in $INPUTFILE -out $OUTPUTFILE
+openssl rsautl -encrypt -pubin -inkey $PATHPUBKEY.pkcs8 -in $INPUTFILE -out $OUTPUTFILE
 
 if [[ $? != 0 ]]; then
   echo "NG：暗号化に失敗しました。ファイルのサイズなど、エラー内容を確認ください。"


### PR DESCRIPTION
私のMac (Mojave)環境で試したところ、OS標準のLibreSSL2.2.xでもbrewインストールしたOpenSSL1.0.2でも、 -sslオプションがついていると、

```
emadurandal@MacBook-Pro:/o/bin > openssl rsautl -encrypt -pubin -inkey github-rsa.pub.pkcs8 -ssl -in test.txt -out test.txt.enc
Usage: rsautl [options]
-in file        input file
-out file       output file
-inkey file     input key
-keyform arg    private key format - default PEM
-pubin          input is an RSA public
-certin         input is a certificate carrying an RSA public key
-ssl            use SSL v2 padding
-raw            use no padding
-pkcs           use PKCS#1 v1.5 padding (default)
-oaep           use PKCS#1 OAEP
-sign           sign with private key
-verify         verify with public key
-encrypt        encrypt with public key
-decrypt        decrypt with private key
-hexdump        hex dump output
```

のようにCommand Usageの表示が出てしまい、正しく処理されない結果となってしまいました。
（以前はうまく言っていた気がするのですが……）

他の方も現在そうなっているのではないかと思い、-sslオプションを取り除いたプルリクを投げさせていただきます。
ご検討いただければ幸いです。

## TL;DR（結論 2019/02/01 現在）

- @KEINOS の VM 上の Mojave にて現象再現＆確認
- 2019/01/29 **マージ済み**。~~QiiCipher へは別途 PR を行い、この PR に言及予定。~~
- 2019/01/30 QiiCipher 修正済み https://github.com/Qithub-BOT/QiiCipher/commit/aee3c87590f4c5cefdad600b3c1d0e0424f60447
